### PR TITLE
Add scroll-to-top button and message character counter

### DIFF
--- a/app.html
+++ b/app.html
@@ -99,7 +99,8 @@
           </div>
           <div>
             <label for="mensaje">Mensaje</label>
-            <textarea id="mensaje" name="mensaje" placeholder="¿Cómo puedo ayudarte?" required></textarea>
+            <textarea id="mensaje" name="mensaje" placeholder="¿Cómo puedo ayudarte?" required maxlength="500"></textarea>
+            <p id="charCount" class="muted char-count">0/500</p>
           </div>
           <div class="inline">
             <button class="btn" type="submit">Enviar</button>
@@ -117,6 +118,8 @@
       <a href="#inicio" class="btn" title="Volver arriba">↑ Arriba</a>
     </div>
   </footer>
+
+  <button id="toTop" class="btn to-top" type="button" aria-label="Volver arriba">↑</button>
 
   <!-- Enlace al archivo JavaScript -->
   <script src="app.js"></script>

--- a/app.js
+++ b/app.js
@@ -70,3 +70,25 @@ const name = (data.nombre || '');
 $('#formMsg').textContent = `¡Gracias${name ? ', ' + name : ''}! Tu mensaje ha sido enviado (simulado).`;
 form.reset();
 });
+
+// ====== Contador de caracteres ======
+const msg = $('#mensaje');
+const charCount = $('#charCount');
+if (msg && charCount) {
+const max = msg.getAttribute('maxlength');
+charCount.textContent = `0/${max}`;
+msg.addEventListener('input', () => {
+charCount.textContent = `${msg.value.length}/${max}`;
+});
+}
+
+// ====== Botón volver arriba ======
+const toTop = $('#toTop');
+if (toTop) {
+window.addEventListener('scroll', () => {
+toTop.classList.toggle('show', window.scrollY > 300);
+});
+toTop.addEventListener('click', () => {
+window.scrollTo({ top: 0, behavior: 'smooth' });
+});
+}

--- a/styles.css
+++ b/styles.css
@@ -99,10 +99,23 @@ label { font-weight: 600; }
 input, textarea { width: 100%; padding: .7rem .8rem; border-radius: .6rem; border: 1px solid color-mix(in oklab, var(--text), transparent 85%); background: var(--surface); color: var(--text); }
 textarea { min-height: 120px; resize: vertical; }
 .inline { display:flex; gap: .75rem; }
+.char-count { margin:.25rem 0 0; text-align:right; font-size:.875rem; }
 
 /* Footer */
 footer { padding: 2rem 0 3rem; border-top: 1px solid color-mix(in oklab, var(--text), transparent 88%); margin-top: 2rem; }
 .foot { display:flex; flex-wrap: wrap; gap: .75rem; justify-content: space-between; align-items:center; color: var(--muted); }
+.to-top {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .3s;
+}
+.to-top.show {
+  opacity: 1;
+  pointer-events: auto;
+}
 
 /* ====== Responsivo ====== */
 @media (max-width: 860px){ .hero .grid { grid-template-columns: 1fr; } }


### PR DESCRIPTION
## Summary
- add character counter with max length for message field
- create floating scroll-to-top button with smooth scroll

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7516fb2848333b2fa83822a8d8367